### PR TITLE
Fix error during yarn

### DIFF
--- a/src/SqlProxyDatasource.ts
+++ b/src/SqlProxyDatasource.ts
@@ -8,7 +8,7 @@ import {
   MutableDataFrame,
   DataFrame,
   guessFieldTypeFromValue, 
-  FieldType
+  FieldType,
 } from '@grafana/data';
 
 import { SqlQuery } from './types';
@@ -58,7 +58,7 @@ export class DataSource extends DataSourceApi<SqlQuery, DataSourceJsonData> {
         return { name: field, type: guessFieldTypeFromValue(array[0][field]) };
       });
       for (const field of fields) {
-        if (field.name.toLowerCase() === "time") {
+        if (field.name.toLowerCase() === 'time') {
           field.type = FieldType.time;
         }
       }
@@ -127,7 +127,7 @@ export class DataSource extends DataSourceApi<SqlQuery, DataSourceJsonData> {
     return getBackendSrv()
       .datasourceRequest({ url })
       .then(res => {
-        return res.data.map(v => ({text: Object.values(v)}));
+        return res.data.map(v => ({ text: Object.values(v) }));
       });
   }
 


### PR DESCRIPTION
grafana-sqlproxy-datasource/src/SqlProxyDatasource.ts

     10:27  error  Delete `·`                                                        prettier/prettier

     11:12  error  Insert `,`                                                        prettier/prettier

     61:42  error  Replace `"time"` with `'time'`                                    prettier/prettier

    130:36  error  Replace `text:·Object.values(v)` with `·text:·Object.values(v)·`  prettier/prettier

  

  ✖ 4 problems (4 errors, 0 warnings)